### PR TITLE
fixed typeError GroupItemMetadataProvider in not a constructor

### DIFF
--- a/src/slick.dataview.js
+++ b/src/slick.dataview.js
@@ -1,6 +1,6 @@
 import Slick                  from './slick.core';
 import $                      from 'jquery';
-import GroupMetaDataProvider  from './slick.groupmetadataprovider';
+import GroupItemMetaDataProvider  from './slick.groupmetadataprovider';
 
 const Aggregators = {
   Avg: AvgAggregator,
@@ -11,7 +11,7 @@ const Aggregators = {
 
 const Data = {
   DataView,
-  GroupMetaDataProvider,
+  GroupItemMetaDataProvider,
   Aggregators
 };
 


### PR DESCRIPTION
[issues #28](https://github.com/DimitarChristoff/slickgrid-es6/issues/28)